### PR TITLE
Two coops had the wrong longitude value so were in the wrong place

### DIFF
--- a/_coops/fractals.md
+++ b/_coops/fractals.md
@@ -6,7 +6,7 @@ website: https://fractals.coop/
 email: hello@fractals.coop
 address: 17 Main Street, Ponteland, Newcastle Upon Tyne, United Kingdom, NE20 9NH
 latitude: 55.0497996
-longitude: 1.7420506
+longitude: -1.7420506
 services: 
 - strategy
 ---

--- a/_coops/impact-box.md
+++ b/_coops/impact-box.md
@@ -6,7 +6,7 @@ website: https://impactbox.coop/
 email: hello@impactbox.coop
 address: Lytchett House Wareham Road, Lytchett Matravers, Poole, England, BH16 6FA
 latitude: 50.7588805 
-longitude: 2.0747285
+longitude: -2.0747285
 clients: 
 services: 
 - strategy


### PR DESCRIPTION
Negative longitude added instead of positive